### PR TITLE
Clean up subscriptions before disconnect

### DIFF
--- a/src/RaftChannelWebSerial.ts
+++ b/src/RaftChannelWebSerial.ts
@@ -192,8 +192,29 @@ export default class RaftChannelWebSerial implements RaftChannel {
 
     RaftLog.debug(`RaftChannelWebSerial.disconnect attempting to close webserial`);
 
-    while (this._reader) {
+    const reader = this._reader;
+    if (reader) {
+      try {
+        await Promise.race([
+          reader.cancel(),
+          new Promise((resolve) => setTimeout(resolve, 1000)),
+        ]);
+      } catch (err) {
+        RaftLog.debug(`RaftChannelWebSerial.disconnect reader cancel failed ${err}`);
+      }
+    }
+
+    const readerReleaseStartMs = Date.now();
+    while (this._reader && Date.now() - readerReleaseStartMs < 1000) {
       await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    if (this._reader) {
+      try {
+        this._reader.releaseLock();
+      } catch (err) {
+        RaftLog.debug(`RaftChannelWebSerial.disconnect reader release failed ${err}`);
+      }
+      this._reader = undefined;
     }
 
     // Disconnect webserial

--- a/src/RaftConnector.ts
+++ b/src/RaftConnector.ts
@@ -25,6 +25,24 @@ import { RaftUpdateEvent, RaftUpdateEventNames } from "./RaftUpdateEvents";
 import RaftUpdateManager from "./RaftUpdateManager";
 import { createBLEChannel } from "./RaftChannelBLEFactory";import { getHostPosixTZ } from './RaftTimezone';
 
+const DISCONNECT_SUBSCRIPTION_TIMEOUT_MS = 1000;
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`timed out after ${timeoutMs}ms`)), timeoutMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      }
+    );
+  });
+}
+
 export default class RaftConnector {
 
   // Get system type callback
@@ -385,6 +403,18 @@ export default class RaftConnector {
       // Store reference to channel before async operations to avoid race condition
       const channelToDisconnect = this._raftChannel;
       this._raftChannel = null;
+
+      if (this._systemType?.subscribeForUpdates && channelToDisconnect.requiresSubscription()) {
+        try {
+          await withTimeout(
+            this._systemType.subscribeForUpdates(this._raftSystemUtils, false),
+            DISCONNECT_SUBSCRIPTION_TIMEOUT_MS
+          );
+          RaftLog.info("disconnect unsubscribed from updates");
+        } catch (error) {
+          RaftLog.warn(`disconnect unsubscribe for updates failed ${error}`);
+        }
+      }
       
       // Check if there is a RICREST command to send before disconnecting
       const ricRestCommand = channelToDisconnect.ricRestCmdBeforeDisconnect();


### PR DESCRIPTION
Ensures raftjs unsubscribes system subscriptions before disconnecting and closes WebSerial cleanly.\n\nChanges:\n- Disable system-type subscriptions before physical disconnect.\n- Cancel and release the WebSerial reader before closing the port.\n\nThis recreates the clean-disconnect change as a separate PR after resetting main.