### PR TITLE
Fix SCD30 CO2 devbin decoding

### DIFF
--- a/src/RaftChannelSimulated.test.ts
+++ b/src/RaftChannelSimulated.test.ts
@@ -1,0 +1,62 @@
+import AttributeHandler from "./RaftAttributeHandler";
+import RaftChannelSimulated from "./RaftChannelSimulated";
+import { DeviceAttributesState, DeviceTimeline } from "./RaftDeviceStates";
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let idx = 0; idx < bytes.length; idx++) {
+    bytes[idx] = parseInt(hex.slice(idx * 2, idx * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+function createTimeline(): DeviceTimeline {
+  return {
+    timestampsUs: [],
+    lastReportTimestampUs: 0,
+    reportTimestampOffsetUs: 0,
+    totalSamplesAdded: 0,
+    emaLastSampleTimeUs: 0,
+    emaIntervalUs: 0,
+    emaPrevPollTimeUs: 0,
+    emaCalibrated: false,
+    emaCalibrationPolls: 0,
+  };
+}
+
+describe("RaftChannelSimulated", () => {
+  test("generates decodable SCD30 CO2, temperature and humidity data", () => {
+    const channel = new RaftChannelSimulated() as any;
+    const deviceTypeInfo = channel._deviceTypeInfo.SCD30;
+    expect(deviceTypeInfo).toBeDefined();
+
+    const msg = channel._createSimulatedDeviceInfoMsg(1000, "SCD30", deviceTypeInfo, 2500) as Uint8Array;
+    const publishedJson = JSON.parse(new TextDecoder().decode(msg.slice(2)));
+    const payload = hexToBytes(publishedJson["1"].SCD30.pub);
+
+    const attrs: DeviceAttributesState = {};
+    const timeline = createTimeline();
+    const handler = new AttributeHandler();
+
+    const nextIdx = handler.processMsgAttrGroup(payload, 0, timeline, deviceTypeInfo.resp, attrs, 100);
+    expect(nextIdx).toBe(26);
+
+    expect(attrs.CO2.values).toHaveLength(1);
+    expect(attrs.temperature.values).toHaveLength(1);
+    expect(attrs.humidity.values).toHaveLength(1);
+
+    const co2 = attrs.CO2.values[0] as number;
+    const temperature = attrs.temperature.values[0] as number;
+    const humidity = attrs.humidity.values[0] as number;
+
+    expect(Number.isFinite(co2)).toBe(true);
+    expect(Number.isFinite(temperature)).toBe(true);
+    expect(Number.isFinite(humidity)).toBe(true);
+    expect(co2).toBeGreaterThanOrEqual(400);
+    expect(co2).toBeLessThanOrEqual(2000);
+    expect(temperature).toBeGreaterThanOrEqual(-40);
+    expect(temperature).toBeLessThanOrEqual(125);
+    expect(humidity).toBeGreaterThanOrEqual(0);
+    expect(humidity).toBeLessThanOrEqual(100);
+  });
+});

--- a/src/RaftChannelSimulated.ts
+++ b/src/RaftChannelSimulated.ts
@@ -588,6 +588,34 @@ export default class RaftChannelSimulated implements RaftChannel {
 
         return true;
       }
+      case "SCD30": {
+        if (dataBlockSizeBytes < 24) {
+          return false;
+        }
+
+        const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+        const co2Ppm = clamp(
+          850 + 320 * Math.sin(deviceTimeMs / 6500) + 45 * Math.sin(deviceTimeMs / 1400),
+          400,
+          2000
+        );
+        const temperatureC = clamp(
+          22 + 2.2 * Math.sin(deviceTimeMs / 11000 + Math.PI / 5),
+          -40,
+          125
+        );
+        const humidityPercent = clamp(
+          48 + 14 * Math.sin(deviceTimeMs / 9000 + Math.PI / 2),
+          0,
+          100
+        );
+
+        return (
+          this._writeFloat32BytesAtOffsets(dataView, bytePos, [6, 7, 9, 10], co2Ppm) &&
+          this._writeFloat32BytesAtOffsets(dataView, bytePos, [12, 13, 15, 16], temperatureC) &&
+          this._writeFloat32BytesAtOffsets(dataView, bytePos, [18, 19, 21, 22], humidityPercent)
+        );
+      }
       case "RoboticalLEDRing": {
         if (dataBlockSizeBytes < 1) {
           return false;
@@ -767,6 +795,30 @@ export default class RaftChannelSimulated implements RaftChannel {
     return bytePos + valueSize;
   }
 
+  private _writeFloat32BytesAtOffsets(
+    dataView: DataView,
+    baseBytePos: number,
+    offsets: number[],
+    value: number
+  ): boolean {
+    if (offsets.length < 4) {
+      return false;
+    }
+
+    const maxOffset = Math.max(...offsets);
+    if (baseBytePos + maxOffset >= dataView.byteLength) {
+      return false;
+    }
+
+    const scratchBuffer = new ArrayBuffer(4);
+    new DataView(scratchBuffer).setFloat32(0, value, false);
+    const bytes = new Uint8Array(scratchBuffer);
+    for (let idx = 0; idx < 4; idx++) {
+      dataView.setUint8(baseBytePos + offsets[idx], bytes[idx]);
+    }
+    return true;
+  }
+
   private _byteSizeForType(typeCode: string): number {
     switch (typeCode) {
       case "b":
@@ -853,6 +905,45 @@ export default class RaftChannelSimulated implements RaftChannel {
               }
           ]
        }
+    },
+    "SCD30": {
+      "name": "CO2 Sensor",
+      "desc": "",
+      "manu": "Sensirion",
+      "type": "SCD30",
+      "clas": ["CO2", "TEMP", "RH"],
+      "resp": {
+        "b": 24,
+        "a": [
+          {
+            "n": "CO2",
+            "t": ">f",
+            "at": [6, 7, 9, 10],
+            "u": "ppm",
+            "r": [0, 40000],
+            "f": ".1f",
+            "o": "float"
+          },
+          {
+            "n": "temperature",
+            "t": ">f",
+            "at": [12, 13, 15, 16],
+            "u": "C",
+            "r": [-40, 125],
+            "f": ".2f",
+            "o": "float"
+          },
+          {
+            "n": "humidity",
+            "t": ">f",
+            "at": [18, 19, 21, 22],
+            "u": "%RH",
+            "r": [0, 100],
+            "f": ".2f",
+            "o": "float"
+          }
+        ]
+      }
     },
     "LSM6DS": {
       "name": "LSM6DS",

--- a/src/RaftDeviceManager.test.ts
+++ b/src/RaftDeviceManager.test.ts
@@ -2,7 +2,7 @@ import { DeviceManager } from "./RaftDeviceManager";
 import { DeviceTypeInfo } from "./RaftDeviceInfo";
 import RaftSystemUtils from "./RaftSystemUtils";
 
-function makeTypeInfo(name: string, respBytes: number, attrs: Array<{ n: string; t: string }>): DeviceTypeInfo {
+function makeTypeInfo(name: string, respBytes: number, attrs: Array<{ n: string; t: string; at?: number | number[] }>): DeviceTypeInfo {
     return {
         name,
         desc: name,
@@ -68,6 +68,40 @@ describe("DeviceManager binary devbin parsing", () => {
         expect(deviceState.deviceAttributes.y.values).toEqual([2]);
         expect(deviceState.deviceAttributes.z.values).toEqual([3]);
         expect(deviceState.deviceAttributes.status.values).toEqual([4]);
+    });
+
+    it("decodes current length-prefixed records with sparse absolute attribute offsets", async () => {
+        const scd30Info = makeTypeInfo("SCD30", 24, [
+            { n: "CO2", t: ">f", at: [6, 7, 9, 10] },
+            { n: "temperature", t: ">f", at: [12, 13, 15, 16] },
+            { n: "humidity", t: ">f", at: [18, 19, 21, 22] }
+        ]);
+        const deviceManager = await makeDeviceManager({ "42": scd30Info });
+        const rxMsg = Uint8Array.from([
+            0x00, 0x80,
+            0xDB, 0xFF, 0x00,
+            0x00, 0x23,
+            0x81,
+            0x00, 0x00, 0x02, 0x61,
+            0x00, 0x2a,
+            0x07,
+            0x1a,
+            0x00, 0x01,
+            0x00, 0x01, 0xb0,
+            0x00, 0x01, 0xb0,
+            0x43, 0xfa, 0x00, 0x00, 0x00, 0x00,
+            0x41, 0xc8, 0x00, 0x00, 0x00, 0x00,
+            0x42, 0x5e, 0x00, 0x00, 0x00, 0x00
+        ]);
+
+        await deviceManager.handleClientMsgBinary(rxMsg);
+
+        const deviceState = deviceManager.getDeviceState("1_261");
+        expect(deviceState.deviceType).toBe("SCD30");
+        expect(deviceState.deviceTimeline.totalSamplesAdded).toBe(1);
+        expect(deviceState.deviceAttributes.CO2.values).toEqual([500]);
+        expect(deviceState.deviceAttributes.temperature.values).toEqual([25]);
+        expect(deviceState.deviceAttributes.humidity.values).toEqual([55.5]);
     });
 
     it("decodes Cog v1.9.5 legacy raw accelerometer records", async () => {

--- a/src/RaftDeviceManager.test.ts
+++ b/src/RaftDeviceManager.test.ts
@@ -104,6 +104,33 @@ describe("DeviceManager binary devbin parsing", () => {
         expect(deviceState.deviceAttributes.humidity.values).toEqual([55.5]);
     });
 
+    it("prefers declared legacy fixed sample size when it matches the record", async () => {
+        const paddedInfo = makeTypeInfo("PaddedFixed", 10, [
+            { n: "first", t: ">H" },
+            { n: "second", t: ">H" }
+        ]);
+        const deviceManager = await makeDeviceManager({ "7": paddedInfo });
+        const rxMsg = Uint8Array.from([
+            0x00, 0x80,
+            0x00, 0x13,
+            0x80,
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0x07,
+            0x00, 0x01,
+            0x00, 0x07,
+            0x00, 0x08,
+            0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff
+        ]);
+
+        await deviceManager.handleClientMsgBinary(rxMsg);
+
+        const deviceState = deviceManager.getDeviceState("0_0_7");
+        expect(deviceState.deviceType).toBe("PaddedFixed");
+        expect(deviceState.deviceTimeline.totalSamplesAdded).toBe(1);
+        expect(deviceState.deviceAttributes.first.values).toEqual([7]);
+        expect(deviceState.deviceAttributes.second.values).toEqual([8]);
+    });
+
     it("decodes Cog v1.9.5 legacy raw accelerometer records", async () => {
         const deviceManager = await makeDeviceManager({ "4": accelInfo });
         const rxMsg = Uint8Array.from([

--- a/src/RaftDeviceManager.ts
+++ b/src/RaftDeviceManager.ts
@@ -553,7 +553,7 @@ export class DeviceManager implements RaftDeviceMgrIF{
                         deviceState.stateChanged = true;
                     }
                 } else {
-                    const fixedSampleLen = this.getDevbinV0FixedSampleLen(pollRespMetadata);
+                    const fixedSampleLen = this.getDevbinV0FixedSampleLen(pollRespMetadata, pollDataPos, samplesEndPos);
                     if (fixedSampleLen <= 0) {
                         this.warnMalformedSample(
                             `${deviceKey}:${devTypeIdx}:DevbinV0FixedLen`,
@@ -983,7 +983,7 @@ export class DeviceManager implements RaftDeviceMgrIF{
                 deviceSeqNumLen: number): DevbinPayloadFormat {
         const framedStartPos = commonRecordHeaderEndPos + deviceSeqNumLen;
         const framedValid = this.areDevbinV1FramedSamplesValid(rxMsg, framedStartPos, samplesEndPos, pollRespMetadata);
-        const fixedSampleLen = this.getDevbinV0FixedSampleLen(pollRespMetadata);
+        const fixedSampleLen = this.getDevbinV0FixedSampleLen(pollRespMetadata, commonRecordHeaderEndPos, samplesEndPos);
         const fixedValid = this.areDevbinV0FixedSamplesValid(commonRecordHeaderEndPos, samplesEndPos, fixedSampleLen);
 
         if (fixedValid && !framedValid) {
@@ -1025,7 +1025,11 @@ export class DeviceManager implements RaftDeviceMgrIF{
             return false;
         }
         const payloadLen = samplesEndPos - pollDataPos;
-        return (payloadLen > 0) && (payloadLen % fixedSampleLen === 0);
+        return this.isDevbinV0FixedSampleLenValid(payloadLen, fixedSampleLen);
+    }
+
+    private isDevbinV0FixedSampleLenValid(payloadLen: number, fixedSampleLen: number): boolean {
+        return (fixedSampleLen > 0) && (payloadLen > 0) && (payloadLen % fixedSampleLen === 0);
     }
 
     private getBinaryDeviceKey(busNum: number, devAddrHex: string, devTypeIdx: number, payloadFormat: DevbinPayloadFormat): string {
@@ -1038,9 +1042,28 @@ export class DeviceManager implements RaftDeviceMgrIF{
         return baseDeviceKey;
     }
 
-    private getDevbinV0FixedSampleLen(pollRespMetadata: DeviceTypePollRespMetadata): number {
+    private getDevbinV0FixedSampleLen(pollRespMetadata: DeviceTypePollRespMetadata, pollDataPos: number, samplesEndPos: number): number {
         const timestampLen = 2;
-        return timestampLen + this.getDevbinV0FixedPayloadSize(pollRespMetadata);
+        const payloadLen = samplesEndPos - pollDataPos;
+        const declaredPayloadLen = pollRespMetadata.b;
+        const declaredSampleLen = declaredPayloadLen > 0 ? timestampLen + declaredPayloadLen : 0;
+        if (this.isDevbinV0FixedSampleLenValid(payloadLen, declaredSampleLen)) {
+            return declaredSampleLen;
+        }
+
+        // DevbinV0Fixed records have no sampleLen prefix, so old firmware
+        // sometimes needs a schema-derived fallback. Prefer .b whenever it
+        // fits the actual record and only fall back when the record length
+        // proves the declared size cannot be the fixed stride.
+        const attrPayloadLen = this.getDevbinV0FixedAttrPayloadSize(pollRespMetadata);
+        const attrSampleLen = attrPayloadLen !== undefined ? timestampLen + attrPayloadLen : 0;
+        if ((attrPayloadLen !== undefined) &&
+                (attrPayloadLen !== declaredPayloadLen) &&
+                this.isDevbinV0FixedSampleLenValid(payloadLen, attrSampleLen)) {
+            return attrSampleLen;
+        }
+
+        return declaredSampleLen;
     }
 
     private getDevbinV1FramedSampleLen(pollRespMetadata: DeviceTypePollRespMetadata): number {
@@ -1051,36 +1074,25 @@ export class DeviceManager implements RaftDeviceMgrIF{
         return timestampLen + pollRespMetadata.b;
     }
 
-    private getDevbinV0FixedPayloadSize(pollRespMetadata: DeviceTypePollRespMetadata): number {
+    private getDevbinV0FixedAttrPayloadSize(pollRespMetadata: DeviceTypePollRespMetadata): number | undefined {
         if (pollRespMetadata.c) {
-            return pollRespMetadata.b;
+            return undefined;
         }
         let attrPayloadLen = 0;
-        let usesAbsolutePositions = false;
         for (const attrDef of pollRespMetadata.a) {
             if (!attrDef.t) {
-                return pollRespMetadata.b;
+                return undefined;
             }
             if (attrDef.at !== undefined) {
-                usesAbsolutePositions = true;
+                return undefined;
             }
             try {
                 attrPayloadLen += structSizeOf(attrDef.t);
             } catch {
-                return pollRespMetadata.b;
+                return undefined;
             }
         }
-        if (usesAbsolutePositions && pollRespMetadata.b > 0) {
-            return pollRespMetadata.b;
-        }
-        // DevbinV0Fixed records have no sampleLen prefix, so the stride must
-        // be inferred. Cog v1.9.5 light metadata reports the direct-sensor
-        // payload size doubled, but the legacy raw record contains one fixed
-        // payload matching the attribute schema.
-        if ((attrPayloadLen > 0) && (pollRespMetadata.b > 0) && (attrPayloadLen <= pollRespMetadata.b)) {
-            return attrPayloadLen;
-        }
-        return pollRespMetadata.b;
+        return attrPayloadLen > 0 ? attrPayloadLen : undefined;
     }
 
     private warnMalformedSample(warningKey: string, message: string): void {

--- a/src/RaftDeviceManager.ts
+++ b/src/RaftDeviceManager.ts
@@ -1003,7 +1003,7 @@ export class DeviceManager implements RaftDeviceMgrIF{
         if (pollDataPos === samplesEndPos) {
             return true;
         }
-        const fixedSampleLen = pollRespMetadata.c ? 0 : this.getDevbinV0FixedSampleLen(pollRespMetadata);
+        const fixedSampleLen = this.getDevbinV1FramedSampleLen(pollRespMetadata);
         let sampleCount = 0;
         while (pollDataPos < samplesEndPos) {
             const sampleLen = rxMsg[pollDataPos];
@@ -1040,17 +1040,29 @@ export class DeviceManager implements RaftDeviceMgrIF{
 
     private getDevbinV0FixedSampleLen(pollRespMetadata: DeviceTypePollRespMetadata): number {
         const timestampLen = 2;
-        return timestampLen + this.getPollRespPayloadSize(pollRespMetadata);
+        return timestampLen + this.getDevbinV0FixedPayloadSize(pollRespMetadata);
     }
 
-    private getPollRespPayloadSize(pollRespMetadata: DeviceTypePollRespMetadata): number {
+    private getDevbinV1FramedSampleLen(pollRespMetadata: DeviceTypePollRespMetadata): number {
+        if (pollRespMetadata.c || pollRespMetadata.b <= 0) {
+            return 0;
+        }
+        const timestampLen = 2;
+        return timestampLen + pollRespMetadata.b;
+    }
+
+    private getDevbinV0FixedPayloadSize(pollRespMetadata: DeviceTypePollRespMetadata): number {
         if (pollRespMetadata.c) {
             return pollRespMetadata.b;
         }
         let attrPayloadLen = 0;
+        let usesAbsolutePositions = false;
         for (const attrDef of pollRespMetadata.a) {
             if (!attrDef.t) {
                 return pollRespMetadata.b;
+            }
+            if (attrDef.at !== undefined) {
+                usesAbsolutePositions = true;
             }
             try {
                 attrPayloadLen += structSizeOf(attrDef.t);
@@ -1058,9 +1070,13 @@ export class DeviceManager implements RaftDeviceMgrIF{
                 return pollRespMetadata.b;
             }
         }
-        // Cog v1.9.5 light metadata reports the direct-sensor payload size
-        // doubled, but the legacy raw record contains one fixed payload
-        // matching the attribute schema.
+        if (usesAbsolutePositions && pollRespMetadata.b > 0) {
+            return pollRespMetadata.b;
+        }
+        // DevbinV0Fixed records have no sampleLen prefix, so the stride must
+        // be inferred. Cog v1.9.5 light metadata reports the direct-sensor
+        // payload size doubled, but the legacy raw record contains one fixed
+        // payload matching the attribute schema.
         if ((attrPayloadLen > 0) && (pollRespMetadata.b > 0) && (attrPayloadLen <= pollRespMetadata.b)) {
             return attrPayloadLen;
         }


### PR DESCRIPTION
## Summary
- Decode SCD30 samples that use sparse absolute attribute offsets without truncating the payload.
- Keep `DevbinV1Framed` validation tied to the length-prefixed sample size and `.b` field, not the sum of attribute sizes.
- Keep the schema-size fallback only for legacy `DevbinV0Fixed` records, where there is no `sampleLen` prefix and Cog v1.9.5 light metadata can over-report `.b`.
- Add SCD30 simulated-device metadata and generated CO2, temperature, and humidity readings.
- Cover both real devbin parsing and simulated SCD30 data generation with focused Jest tests.

## Root Cause
SCD30 response metadata declares a 24-byte payload with attributes located at absolute byte offsets such as `[6, 7, 9, 10]`. The parser was reusing the legacy fixed-record stride calculation while validating current length-prefixed records. That calculation summed the declared attribute struct sizes, producing 12 payload bytes for three floats instead of respecting the 24-byte `.b` payload.

## Fix
`DevbinV1Framed` records now validate fixed-size samples as `timestamp + pollRespMetadata.b`, while variable/custom responses skip that fixed-size check. The attribute-size sum remains scoped to `DevbinV0Fixed`, where old firmware has no per-sample length prefix and one known compatibility case requires deriving the legacy stride from the attribute schema. Schemas with explicit absolute offsets still use `.b` because summing attribute sizes would ignore gaps.

The simulator also includes SCD30 type info and writes float bytes into the same sparse absolute positions so app-level simulated hardware can exercise the same path.

## Validation
- `npx jest src/RaftDeviceManager.test.ts src/RaftChannelSimulated.test.ts --runInBand`
- `npm run build-all`
- `npm run lint`